### PR TITLE
Add Pulumi deploy workflow

### DIFF
--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -1,0 +1,46 @@
+name: Pulumi Up
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  pulumi-up:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install -r infra/requirements.txt
+
+      - name: Pulumi Up
+        uses: pulumi/actions@v4
+        with:
+          command: up
+          work-dir: infra
+          stack-name: dev
+          args: --yes
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          AWS_REGION: us-west-2
+          AWS_DEFAULT_REGION: us-west-2
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+
+      - name: Set AWS region config
+        if: ${{ always() }}
+        run: pulumi -C infra config set aws:region us-west-2
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          AWS_REGION: us-west-2
+          AWS_DEFAULT_REGION: us-west-2
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow to run pulumi up from infra/ in us-west-2. Requires PULUMI_ACCESS_TOKEN and AWS credentials in repo secrets.