### PR TITLE
Select Pulumi stack in workflow

### DIFF
--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -28,6 +28,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-west-2
 
+      - name: Select Pulumi stack
+        run: pulumi -C infra stack select dev || pulumi -C infra stack init dev
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
       - name: Set AWS region config
         run: pulumi -C infra config set aws:region us-west-2
         env:


### PR DESCRIPTION
Fixes Pulumi workflow by selecting or initializing the dev stack before setting config.