### PR TITLE
Adopt existing OpenSearch network policy

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -69,6 +69,7 @@ network_policy = aws_native.opensearchserverless.SecurityPolicy(
             }
         ]
     ),
+    opts=pulumi.ResourceOptions(import_=f"{network_policy_name}|network"),
 )
 
 collection = aws_native.opensearchserverless.Collection(


### PR DESCRIPTION
Import existing OpenSearch Serverless network policy so Pulumi can adopt it.