### PR TITLE
Fix IAM policy JSON serialization

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -100,7 +100,7 @@ lambda_role = aws.iam.Role(
 
 lambda_policy = aws.iam.Policy(
     "ragLambdaPolicy",
-    policy=json.dumps(
+    policy=pulumi.Output.json_dumps(
         {
             "Version": "2012-10-17",
             "Statement": [


### PR DESCRIPTION
Use pulumi.Output.json_dumps so IAM policy can include Output values.