### PR TITLE
Add permissions to OpenSearch access policy

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -154,10 +154,20 @@ access_policy = aws_native.opensearchserverless.AccessPolicy(
                         {
                             "ResourceType": "collection",
                             "Resource": [f"collection/{collection_name}"],
+                            "Permission": [
+                                "aoss:DescribeCollectionItems",
+                                "aoss:CreateCollectionItems",
+                                "aoss:UpdateCollectionItems",
+                                "aoss:DeleteCollectionItems",
+                            ],
                         },
                         {
                             "ResourceType": "index",
                             "Resource": [f"index/{collection_name}/*"],
+                            "Permission": [
+                                "aoss:ReadDocument",
+                                "aoss:WriteDocument",
+                            ],
                         },
                     ],
                     "Principal": [args[0]],


### PR DESCRIPTION
Add required Permission entries to OpenSearch Serverless access policy rules.