### PR TITLE
Import existing OpenSearch access policy

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -175,6 +175,7 @@ access_policy = aws_native.opensearchserverless.AccessPolicy(
             ]
         )
     ),
+    opts=pulumi.ResourceOptions(import_=f"data|{access_policy_name}"),
 )
 
 lambda_env = {


### PR DESCRIPTION
Adopt the existing OpenSearch Serverless access policy into Pulumi state for the one-time import.