### PR TITLE
Issue #59 Phase 1: index mapping bootstrap and ingest upsert

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -24,6 +24,7 @@ encryption_policy_name = limited_name("enc")
 network_policy_name = limited_name("net")
 access_policy_name = limited_name("access")
 index_name = "artifacts"
+aws_region = aws.get_region().name
 
 artifacts_bucket = aws.s3.Bucket(
     "artifactsBucket",
@@ -178,8 +179,15 @@ access_policy = aws_native.opensearchserverless.AccessPolicy(
 lambda_env = {
     "ARTIFACTS_BUCKET": artifacts_bucket.bucket,
     "OPENSEARCH_COLLECTION": collection.name,
+    "OPENSEARCH_ENDPOINT": collection.collection_endpoint,
+    "OPENSEARCH_REGION": aws_region,
     "OPENSEARCH_INDEX": index_name,
+    "OPENSEARCH_VECTOR_DIMENSION": "1024",
+    "ENABLE_EMBED_UPSERT": "true",
     "BEDROCK_EMBED_MODEL": "amazon.titan-embed-text-v2:0",
+    "BEDROCK_REGION": aws_region,
+    "CHUNK_TARGET_CHARS": "900",
+    "CHUNK_OVERLAP_CHARS": "120",
 }
 
 ingest_lambda = aws.lambda_.Function(

--- a/infra/lambdas/ingest/handler.py
+++ b/infra/lambdas/ingest/handler.py
@@ -3,12 +3,26 @@ import json
 import os
 import re
 from typing import Any, Dict, List, Tuple
+from urllib.parse import urlparse
 
 import boto3
+import urllib3
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.exceptions import ClientError
 
 
 CHUNK_TARGET_CHARS = int(os.getenv("CHUNK_TARGET_CHARS", "900"))
 CHUNK_OVERLAP_CHARS = int(os.getenv("CHUNK_OVERLAP_CHARS", "120"))
+OPENSEARCH_INDEX = os.getenv("OPENSEARCH_INDEX", "artifacts")
+OPENSEARCH_ENDPOINT = os.getenv("OPENSEARCH_ENDPOINT", "")
+OPENSEARCH_REGION = os.getenv("OPENSEARCH_REGION", os.getenv("AWS_REGION", "us-west-2"))
+OPENSEARCH_VECTOR_DIMENSION = int(os.getenv("OPENSEARCH_VECTOR_DIMENSION", "1024"))
+BEDROCK_EMBED_MODEL = os.getenv("BEDROCK_EMBED_MODEL", "amazon.titan-embed-text-v2:0")
+BEDROCK_REGION = os.getenv("BEDROCK_REGION", os.getenv("AWS_REGION", "us-west-2"))
+ENABLE_EMBED_UPSERT = os.getenv("ENABLE_EMBED_UPSERT", "true").lower() == "true"
+
+HTTP = urllib3.PoolManager()
 
 
 def normalize_doc_id(source_key: str) -> str:
@@ -151,6 +165,151 @@ def load_artifact_from_s3(bucket: str, key: str) -> Dict[str, Any]:
     return json.loads(payload)
 
 
+def _normalized_opensearch_endpoint() -> str:
+    endpoint = OPENSEARCH_ENDPOINT.strip()
+    if not endpoint:
+        return ""
+    if not endpoint.startswith("http://") and not endpoint.startswith("https://"):
+        endpoint = f"https://{endpoint}"
+    return endpoint.rstrip("/")
+
+
+def _signed_aoss_request(method: str, path: str, payload: Any = None, content_type: str = "application/json"):
+    endpoint = _normalized_opensearch_endpoint()
+    if not endpoint:
+        raise RuntimeError("OPENSEARCH_ENDPOINT is not configured")
+
+    url = f"{endpoint}{path}"
+    body = None
+    if payload is not None:
+        if isinstance(payload, str):
+            body = payload.encode("utf-8")
+        elif isinstance(payload, bytes):
+            body = payload
+        else:
+            body = json.dumps(payload).encode("utf-8")
+
+    session = boto3.Session()
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise RuntimeError("AWS credentials unavailable for OpenSearch request signing")
+
+    aws_request = AWSRequest(
+        method=method,
+        url=url,
+        data=body,
+        headers={"Content-Type": content_type},
+    )
+    SigV4Auth(credentials, "aoss", OPENSEARCH_REGION).add_auth(aws_request)
+    prepared = aws_request.prepare()
+
+    response = HTTP.request(
+        method=method,
+        url=url,
+        body=body,
+        headers=dict(prepared.headers.items()),
+        retries=False,
+    )
+    return response
+
+
+def _ensure_index_mapping(vector_dimension: int) -> str:
+    head_response = _signed_aoss_request("HEAD", f"/{OPENSEARCH_INDEX}", payload=None)
+    if head_response.status == 200:
+        return "exists"
+    if head_response.status != 404:
+        raise RuntimeError(
+            f"Unable to check index state for '{OPENSEARCH_INDEX}': status={head_response.status}"
+        )
+
+    mapping_payload = {
+        "settings": {"index": {"knn": True}},
+        "mappings": {
+            "properties": {
+                "id": {"type": "keyword"},
+                "doc_id": {"type": "keyword"},
+                "chunk_id": {"type": "keyword"},
+                "text": {"type": "text"},
+                "embedding": {
+                    "type": "knn_vector",
+                    "dimension": vector_dimension,
+                    "method": {"name": "hnsw", "engine": "faiss", "space_type": "cosinesimil"},
+                },
+                "metadata": {
+                    "properties": {
+                        "source_key": {"type": "keyword"},
+                        "topic": {"type": "keyword"},
+                        "version": {"type": "keyword"},
+                        "section_type": {"type": "keyword"},
+                        "section_index": {"type": "integer"},
+                        "chunk_index": {"type": "integer"},
+                        "total_chunks_in_section": {"type": "integer"},
+                        "prohibited_topics_detected": {"type": "keyword"},
+                    }
+                },
+            }
+        },
+    }
+
+    create_response = _signed_aoss_request("PUT", f"/{OPENSEARCH_INDEX}", payload=mapping_payload)
+    if create_response.status not in (200, 201):
+        raise RuntimeError(
+            f"Index create failed for '{OPENSEARCH_INDEX}': status={create_response.status}, body={create_response.data.decode('utf-8', errors='ignore')}"
+        )
+    return "created"
+
+
+def _embed_text(text: str) -> List[float]:
+    bedrock_client = boto3.client("bedrock-runtime", region_name=BEDROCK_REGION)
+    try:
+        response = bedrock_client.invoke_model(
+            modelId=BEDROCK_EMBED_MODEL,
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps({"inputText": text}),
+        )
+    except ClientError as exc:
+        raise RuntimeError(f"Bedrock embedding call failed: {exc}") from exc
+
+    payload = json.loads(response["body"].read())
+    return payload.get("embedding", [])
+
+
+def _embed_chunk_documents(chunk_documents: List[Dict[str, Any]]) -> int:
+    embedded = 0
+    for chunk_doc in chunk_documents:
+        embedding = _embed_text(chunk_doc["text"])
+        if not embedding:
+            raise RuntimeError(f"Empty embedding returned for chunk_id={chunk_doc['chunk_id']}")
+        chunk_doc["embedding"] = embedding
+        embedded += 1
+    return embedded
+
+
+def _bulk_upsert_documents(chunk_documents: List[Dict[str, Any]]) -> int:
+    lines: List[str] = []
+    for chunk_doc in chunk_documents:
+        lines.append(json.dumps({"index": {"_index": OPENSEARCH_INDEX, "_id": chunk_doc["id"]}}))
+        lines.append(json.dumps(chunk_doc))
+    payload = "\n".join(lines) + "\n"
+
+    response = _signed_aoss_request(
+        "POST",
+        f"/{OPENSEARCH_INDEX}/_bulk",
+        payload=payload,
+        content_type="application/x-ndjson",
+    )
+    if response.status not in (200, 201):
+        raise RuntimeError(
+            f"Bulk upsert failed: status={response.status}, body={response.data.decode('utf-8', errors='ignore')}"
+        )
+
+    body = json.loads(response.data.decode("utf-8"))
+    if body.get("errors"):
+        raise RuntimeError(f"Bulk upsert returned item errors: {json.dumps(body)[:1000]}")
+    return len(chunk_documents)
+
+
 def handler(event, context):
     records = event.get("Records", [])
     chunk_documents: List[Dict[str, Any]] = []
@@ -177,6 +336,9 @@ def handler(event, context):
         "status": "ok",
         "processed_sources": processed_sources,
         "chunk_count": len(chunk_documents),
+        "embedded_count": 0,
+        "upserted_count": 0,
+        "index_status": "not_attempted",
         "chunking_config": {
             "target_chars": CHUNK_TARGET_CHARS,
             "overlap_chars": CHUNK_OVERLAP_CHARS,
@@ -184,6 +346,31 @@ def handler(event, context):
         "chunks": chunk_documents,
         "next_step": "embed_and_upsert_pending",
     }
+
+    if not chunk_documents:
+        result["next_step"] = "no_chunks"
+        print(json.dumps({"summary": {k: v for k, v in result.items() if k != "chunks"}}))
+        return result
+
+    if not ENABLE_EMBED_UPSERT:
+        result["next_step"] = "embed_upsert_disabled"
+        print(json.dumps({"summary": {k: v for k, v in result.items() if k != "chunks"}}))
+        return result
+
+    if not _normalized_opensearch_endpoint():
+        result["next_step"] = "missing_opensearch_endpoint"
+        print(json.dumps({"summary": {k: v for k, v in result.items() if k != "chunks"}}))
+        return result
+
+    embedded_count = _embed_chunk_documents(chunk_documents)
+    vector_dimension = len(chunk_documents[0].get("embedding") or []) or OPENSEARCH_VECTOR_DIMENSION
+    index_status = _ensure_index_mapping(vector_dimension)
+    upserted_count = _bulk_upsert_documents(chunk_documents)
+
+    result["embedded_count"] = embedded_count
+    result["upserted_count"] = upserted_count
+    result["index_status"] = index_status
+    result["next_step"] = "ingest_completed"
 
     print(json.dumps({"summary": {k: v for k, v in result.items() if k != "chunks"}}))
     return result


### PR DESCRIPTION
## Summary
This PR delivers Phase 1 of Issue #59 (Vector Store & Retrieval API): index mapping bootstrap + ingest upsert.

### Included in this slice
- Adds OpenSearch index bootstrap from ingest path (create index if missing).
- Adds Bedrock Titan v2 embedding generation per chunk.
- Adds OpenSearch bulk upsert for embedded chunk documents.
- Wires infra Lambda environment variables for endpoint/index/region/vector dimension.

### Implementation notes
- Chunking contract from #57 is reused as the source of chunk documents.
- Ingest returns clear next-step statuses when endpoint/upsert is not configured.
- Mapping includes id, doc_id, chunk_id, 	ext, embedding, and metadata fields.

## Validation
- Local ingest simulation (inline artifact) succeeds and returns chunk summary.
- Local simulation correctly reports missing_opensearch_endpoint without attempting network calls.
- Static diagnostics report no errors in updated files.

## Follow-up (next slices for #59)
- Phase 2: query lambda top-k retrieval API
- Phase 3: metadata filters + confidence logging + eval baseline

Refs #59