### PR TITLE
Issue #59 Phase 3: filter hardening, confidence logs, eval baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ Behavior:
 Config via env vars:
 - `BEDROCK_REGION` (default: us-west-2)
 - `BEDROCK_MODEL_ID` (default: amazon.titan-embed-text-v2:0)
+
+## Retrieval baseline eval
+
+Run retrieval baseline scoring against the query handler using the seed eval set:
+
+```bash
+python scripts/eval_retrieval_baseline.py --top-k 5
+```
+
+Output report is written to `artifacts/eval/retrieval_baseline.json`.
+
+Query API (Lambda handler) supports:
+- `metadata_filter` (allowlisted metadata keys only)
+- confidence summary in response (`score_max`, `score_min`, `score_avg`, `confidence_band`)

--- a/infra/lambdas/query/handler.py
+++ b/infra/lambdas/query/handler.py
@@ -1,5 +1,7 @@
 import json
 import os
+import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple
 
 import boto3
@@ -18,6 +20,14 @@ BEDROCK_EMBED_MODEL = os.getenv("BEDROCK_EMBED_MODEL", "amazon.titan-embed-text-
 BEDROCK_REGION = os.getenv("BEDROCK_REGION", os.getenv("AWS_REGION", "us-west-2"))
 DEFAULT_TOP_K = int(os.getenv("RETRIEVAL_TOP_K", "5"))
 MAX_TOP_K = int(os.getenv("RETRIEVAL_TOP_K_MAX", "20"))
+FILTER_ALLOWLIST = {
+    item.strip()
+    for item in os.getenv(
+        "RETRIEVAL_FILTER_ALLOWLIST",
+        "topic,version,section_type,source_key,section_index,chunk_index,doc_id,chunk_id",
+    ).split(",")
+    if item.strip()
+}
 
 
 def _normalized_endpoint() -> str:
@@ -112,6 +122,38 @@ def _parse_event(event: Dict[str, Any]) -> Tuple[str, int, Dict[str, Any]]:
     return question, top_k, metadata_filter
 
 
+def _is_scalar_filter_value(value: Any) -> bool:
+    return isinstance(value, (str, int, float, bool))
+
+
+def _sanitize_metadata_filter(metadata_filter: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    sanitized: Dict[str, Any] = {}
+    rejected_fields: List[str] = []
+
+    for field, raw_value in metadata_filter.items():
+        if field not in FILTER_ALLOWLIST:
+            rejected_fields.append(field)
+            continue
+
+        if raw_value is None:
+            continue
+
+        if isinstance(raw_value, list):
+            cleaned_values = [item for item in raw_value if _is_scalar_filter_value(item)]
+            if cleaned_values:
+                sanitized[field] = cleaned_values
+            else:
+                rejected_fields.append(field)
+            continue
+
+        if _is_scalar_filter_value(raw_value):
+            sanitized[field] = raw_value
+        else:
+            rejected_fields.append(field)
+
+    return sanitized, rejected_fields
+
+
 def _build_filter_clause(metadata_filter: Dict[str, Any]) -> List[Dict[str, Any]]:
     clauses: List[Dict[str, Any]] = []
     for field, value in metadata_filter.items():
@@ -173,36 +215,118 @@ def _normalize_results(hits: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return results
 
 
+def _summarize_confidence(results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    scores = [result.get("score") for result in results if isinstance(result.get("score"), (int, float))]
+    if not scores:
+        return {
+            "score_max": None,
+            "score_min": None,
+            "score_avg": None,
+            "confidence_band": "none",
+        }
+
+    score_max = max(scores)
+    score_min = min(scores)
+    score_avg = sum(scores) / len(scores)
+
+    if score_max >= 0.8:
+        confidence_band = "high"
+    elif score_max >= 0.5:
+        confidence_band = "medium"
+    else:
+        confidence_band = "low"
+
+    return {
+        "score_max": score_max,
+        "score_min": score_min,
+        "score_avg": score_avg,
+        "confidence_band": confidence_band,
+    }
+
+
 def handler(event, context):
+    query_id = str(uuid.uuid4())
+    request_timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
     try:
         question, top_k, metadata_filter = _parse_event(event or {})
     except ValueError as exc:
-        return {"statusCode": 400, "body": json.dumps({"status": "error", "message": str(exc)})}
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {"status": "error", "message": str(exc), "query_id": query_id, "timestamp": request_timestamp}
+            ),
+        }
+
+    sanitized_filter, rejected_filter_fields = _sanitize_metadata_filter(metadata_filter)
 
     endpoint = _normalized_endpoint()
     if not endpoint:
         body = {
             "status": "ok",
+            "query_id": query_id,
+            "timestamp": request_timestamp,
             "question": question,
             "top_k": top_k,
-            "metadata_filter": metadata_filter,
+            "metadata_filter": sanitized_filter,
+            "rejected_filter_fields": rejected_filter_fields,
             "retrieval_count": 0,
             "results": [],
+            "confidence": _summarize_confidence([]),
             "next_step": "missing_opensearch_endpoint",
         }
+        print(
+            json.dumps(
+                {
+                    "retrieval_trace": {
+                        "query_id": query_id,
+                        "timestamp": request_timestamp,
+                        "top_k": top_k,
+                        "metadata_filter": sanitized_filter,
+                        "rejected_filter_fields": rejected_filter_fields,
+                        "retrieval_count": 0,
+                        "confidence": body["confidence"],
+                        "next_step": body["next_step"],
+                    }
+                }
+            )
+        )
         return {"statusCode": 200, "body": json.dumps(body)}
 
     question_embedding = _embed_question(question)
-    hits = _vector_search(question_embedding, top_k, metadata_filter)
+    hits = _vector_search(question_embedding, top_k, sanitized_filter)
     results = _normalize_results(hits)
+    confidence = _summarize_confidence(results)
 
     body = {
         "status": "ok",
+        "query_id": query_id,
+        "timestamp": request_timestamp,
         "question": question,
         "top_k": top_k,
-        "metadata_filter": metadata_filter,
+        "metadata_filter": sanitized_filter,
+        "rejected_filter_fields": rejected_filter_fields,
         "retrieval_count": len(results),
+        "confidence": confidence,
         "results": results,
         "next_step": "llm_answer_generation_pending",
     }
+
+    print(
+        json.dumps(
+            {
+                "retrieval_trace": {
+                    "query_id": query_id,
+                    "timestamp": request_timestamp,
+                    "top_k": top_k,
+                    "metadata_filter": sanitized_filter,
+                    "rejected_filter_fields": rejected_filter_fields,
+                    "retrieval_count": len(results),
+                    "confidence": confidence,
+                    "result_ids": [item.get("id") for item in results],
+                }
+            }
+        )
+    )
+
     return {"statusCode": 200, "body": json.dumps(body)}

--- a/scripts/eval_retrieval_baseline.py
+++ b/scripts/eval_retrieval_baseline.py
@@ -1,0 +1,163 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from infra.lambdas.query.handler import handler
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run retrieval baseline evaluation against query Lambda handler.")
+    parser.add_argument(
+        "--eval-file",
+        default="tests/rag/eval_questions_seed_v1.json",
+        help="Path to eval questions JSON file",
+    )
+    parser.add_argument("--top-k", type=int, default=5, help="Top-k retrieval depth for each eval question")
+    parser.add_argument(
+        "--output",
+        default="artifacts/eval/retrieval_baseline.json",
+        help="Path to write evaluation summary JSON",
+    )
+    parser.add_argument(
+        "--stop-on-error",
+        action="store_true",
+        help="Stop evaluation immediately if a handler invocation fails",
+    )
+    return parser.parse_args()
+
+
+def load_eval_questions(path: Path) -> List[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, list):
+        raise ValueError("Eval file must contain a JSON array")
+    return payload
+
+
+def topic_hit(results: List[Dict[str, Any]], expected_topic: str) -> Dict[str, bool]:
+    normalized_expected = (expected_topic or "").strip().lower()
+    observed_topics = [
+        (item.get("metadata", {}).get("topic") or "").strip().lower()
+        for item in results
+    ]
+    top1_hit = bool(observed_topics) and observed_topics[0] == normalized_expected
+    topk_hit = normalized_expected in observed_topics
+    return {"top1_hit": top1_hit, "topk_hit": topk_hit}
+
+
+def invoke_query(question: str, top_k: int) -> Dict[str, Any]:
+    response = handler({"question": question, "top_k": top_k}, None)
+    status_code = response.get("statusCode", 500)
+    body = response.get("body")
+    parsed = json.loads(body) if isinstance(body, str) else body
+    return {"status_code": status_code, "body": parsed}
+
+
+def main() -> int:
+    args = parse_args()
+    eval_path = Path(args.eval_file)
+    output_path = Path(args.output)
+
+    questions = load_eval_questions(eval_path)
+
+    rows: List[Dict[str, Any]] = []
+    total = 0
+    top1_hits = 0
+    topk_hits = 0
+    error_count = 0
+
+    for item in questions:
+        total += 1
+        qid = item.get("id")
+        question = item.get("question", "")
+        expected_topic = item.get("expected_topic", "")
+
+        try:
+            result = invoke_query(question, args.top_k)
+        except Exception as exc:  # noqa: BLE001
+            error_count += 1
+            rows.append(
+                {
+                    "id": qid,
+                    "question": question,
+                    "expected_topic": expected_topic,
+                    "status": "error",
+                    "error": str(exc),
+                }
+            )
+            if args.stop_on_error:
+                break
+            continue
+
+        status_code = result["status_code"]
+        body = result["body"] if isinstance(result["body"], dict) else {}
+        retrieval_count = body.get("retrieval_count", 0)
+        results = body.get("results", []) if isinstance(body.get("results"), list) else []
+        confidence = body.get("confidence", {})
+
+        if status_code != 200:
+            error_count += 1
+            rows.append(
+                {
+                    "id": qid,
+                    "question": question,
+                    "expected_topic": expected_topic,
+                    "status": "error",
+                    "status_code": status_code,
+                    "response": body,
+                }
+            )
+            if args.stop_on_error:
+                break
+            continue
+
+        hits = topic_hit(results, expected_topic)
+        if hits["top1_hit"]:
+            top1_hits += 1
+        if hits["topk_hit"]:
+            topk_hits += 1
+
+        rows.append(
+            {
+                "id": qid,
+                "question": question,
+                "expected_topic": expected_topic,
+                "status": "ok",
+                "retrieval_count": retrieval_count,
+                "top1_hit": hits["top1_hit"],
+                "topk_hit": hits["topk_hit"],
+                "confidence": confidence,
+            }
+        )
+
+    evaluated = max(1, total - error_count)
+    summary = {
+        "eval_file": str(eval_path),
+        "top_k": args.top_k,
+        "total_questions": total,
+        "errors": error_count,
+        "top1_hits": top1_hits,
+        "topk_hits": topk_hits,
+        "top1_hit_rate": top1_hits / evaluated,
+        "topk_hit_rate": topk_hits / evaluated,
+    }
+
+    output = {"summary": summary, "results": rows}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(output, handle, indent=2)
+
+    print(json.dumps(summary, indent=2))
+    print(f"Saved baseline report to: {output_path}")
+
+    return 0 if error_count == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR delivers Phase 3 of Issue #59: metadata filter hardening, confidence logging, and eval baseline capture.

### Included in this slice
- Hardens metadata_filter handling with an allowlist and value sanitization.
- Returns ejected_filter_fields so callers can detect ignored filter inputs.
- Adds confidence summary fields (score_max, score_min, score_avg, confidence_band).
- Emits structured retrieval trace logs per query (query_id, timestamp, filters, result IDs, confidence).
- Adds retrieval baseline script: scripts/eval_retrieval_baseline.py.

### Validation
- Query handler local smoke test validates:
  - unknown filter fields are rejected and reported,
  - confidence structure is always present,
  - graceful fallback when endpoint is missing.
- Baseline script CLI loads and runs:
  - python scripts/eval_retrieval_baseline.py --help
  - python scripts/eval_retrieval_baseline.py --top-k 5

## Notes
- Baseline hit rates will reflect deployed retrieval readiness; local runs with missing endpoint return zero retrievals by design.

Refs #59