### PR TITLE
Fix validate-artifacts tasks default args

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,11 @@
 			"type": "shell",
 			"command": "C:/Users/sjpig/OneDrive/Desktop/Mortgage-LO-App--MVP/.venv/Scripts/python.exe",
 			"args": [
-				"scripts/validate_artifacts.py"
+				"scripts/validate_artifacts.py",
+				"--schema",
+				"schemas/extraction_artifact.schema.json",
+				"--glob",
+				"artifacts/seed_v1/*.json"
 			]
 		},
 		{
@@ -15,7 +19,7 @@
 			"command": "cmd",
 			"args": [
 				"/c",
-				"C:\\Users\\sjpig\\OneDrive\\Desktop\\Mortgage-LO-App--MVP\\.venv\\Scripts\\python.exe scripts\\validate_artifacts.py"
+				"C:\\Users\\sjpig\\OneDrive\\Desktop\\Mortgage-LO-App--MVP\\.venv\\Scripts\\python.exe scripts\\validate_artifacts.py --schema schemas\\extraction_artifact.schema.json --glob artifacts\\seed_v1\\*.json"
 			]
 		},
 		{


### PR DESCRIPTION
## Summary
- update .vscode/tasks.json so validate-artifacts passes required --schema and --glob arguments
- align validate-artifacts-cmd with the same defaults

## Validation
- run task: validate-artifacts -> Validated 10 file(s) successfully
- run task: validate-artifacts-cmd -> Validated 10 file(s) successfully